### PR TITLE
Allow dynamic pool startup

### DIFF
--- a/src/riakc_poolboy.erl
+++ b/src/riakc_poolboy.erl
@@ -2,7 +2,8 @@
 
 -include_lib("riakc/include/riakc.hrl").
 
--export([get_server_info/1, get_server_info/2,
+-export([start_pool/3,
+         get_server_info/1, get_server_info/2,
          get/3, get/4, get/5,
          put/2, put/3, put/4,
          delete/3, delete/4, delete/5,
@@ -17,6 +18,10 @@
          search/3, search/4, search/5, search/6,
          get_index/4, get_index/5, get_index/6, get_index/7,
          tunnel/4]).
+
+-spec start_pool(atom(), list(term()), list(term())) -> supervisor:startlink_ret().
+start_pool(Name, SizeArgs, WorkerArgs) ->
+    riakc_poolboy_sup:start_link(Name, SizeArgs, WorkerArgs).
 
 -type msg_id() :: non_neg_integer(). %% Request identifier for tunneled message types
 

--- a/src/riakc_poolboy_sup.erl
+++ b/src/riakc_poolboy_sup.erl
@@ -2,12 +2,20 @@
 
 -behaviour(supervisor).
 
--export([start_link/0]).
+-export([start_link/0,
+         start_link/3]).
 
 -export([init/1]).
 
 start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+start_link(Name, SizeArgs, WorkerArgs) ->
+    PoolArgs =
+        [{name, {local, Name}},
+         {worker_module, riakc_poolboy_worker}] ++ SizeArgs,
+    PoolSpec = poolboy:child_spec(Name, PoolArgs, WorkerArgs),
+    supervisor:start_child(?MODULE, PoolSpec).
 
 init([]) ->
     {ok, Pools} = application:get_env(riakc_poolboy, pools),


### PR DESCRIPTION
Make it possible to start pool dynamically and not upon riakc_poolboy
startup, by calling `riakc_poolboy:start_pool/3`.
