### PR TITLE
Add travis ci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ ebin/*.beam
 deps
 test/*.beam
 logs
+.rebar

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+sudo: false
+language: erlang
+otp_release:
+  - 17.5
+services:
+  - riak
+script: make deps compile test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Riak Protocol Buffers Client Pool
 
+[![Build Status][travis_ci_image]][travis_ci]
+
 About
 =========
 
@@ -29,3 +31,6 @@ TODO
 
 * Support streaming functions
 * Tests
+
+[travis_ci]: https://travis-ci.org/puzza007/riakc_poolboy
+[travis_ci_image]: https://travis-ci.org/puzza007/riakc_poolboy.png


### PR DESCRIPTION
The required version of meck relies on OTP < 18 so only test against 17.5 for now